### PR TITLE
Estimate scalability coefficient from past scaling history using linear regression

### DIFF
--- a/docs/layouts/shortcodes/generated/auto_scaler_configuration.html
+++ b/docs/layouts/shortcodes/generated/auto_scaler_configuration.html
@@ -99,6 +99,24 @@
             <td>Scaling metrics aggregation window size.</td>
         </tr>
         <tr>
+            <td><h5>job.autoscaler.observed-scalability.coefficient-min</h5></td>
+            <td style="word-wrap: break-word;">0.5</td>
+            <td>Double</td>
+            <td>Minimum allowed value for the observed scalability coefficient. Prevents aggressive scaling by clamping low coefficient estimates. If the estimated coefficient falls below this value, it is capped at the configured minimum.</td>
+        </tr>
+        <tr>
+            <td><h5>job.autoscaler.observed-scalability.enabled</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>Enables the use of an observed scalability coefficient when computing target parallelism. If enabled, the system will estimate the scalability coefficient based on historical scaling data instead of assuming perfect linear scaling. This helps account for real-world inefficiencies such as network overhead and coordination costs.</td>
+        </tr>
+        <tr>
+            <td><h5>job.autoscaler.observed-scalability.min-observations</h5></td>
+            <td style="word-wrap: break-word;">3</td>
+            <td>Integer</td>
+            <td>Defines the minimum number of historical scaling observations required to estimate the scalability coefficient. If the number of available observations is below this threshold, the system falls back to assuming linear scaling. Note: To effectively use a higher minimum observation count, you need to increase job.autoscaler.history.max.count. Avoid setting job.autoscaler.history.max.count to a very high value, as the number of retained data points is limited by the size of the state store—particularly when using Kubernetes-based state store.</td>
+        </tr>
+        <tr>
             <td><h5>job.autoscaler.observed-true-processing-rate.lag-threshold</h5></td>
             <td style="word-wrap: break-word;">30 s</td>
             <td>Duration</td>

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/JobVertexScaler.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/JobVertexScaler.java
@@ -185,9 +185,9 @@ public class JobVertexScaler<KEY, Context extends JobAutoScalerContext<KEY>> {
         LOG.debug("Target processing capacity for {} is {}", vertex, targetCapacity);
         double scaleFactor = targetCapacity / averageTrueProcessingRate;
         if (conf.get(OBSERVED_SCALABILITY_ENABLED)) {
+
             double scalingCoefficient =
-                    JobVertexScaler.calculateObservedScalingCoefficient(
-                            history, conf.get(OBSERVED_SCALABILITY_MIN_OBSERVATIONS));
+                    JobVertexScaler.calculateObservedScalingCoefficient(history, conf);
             scaleFactor = scaleFactor / scalingCoefficient;
         }
         double minScaleFactor = 1 - conf.get(MAX_SCALE_DOWN_FACTOR);
@@ -251,22 +251,19 @@ public class JobVertexScaler<KEY, Context extends JobAutoScalerContext<KEY>> {
     /**
      * Calculates the scaling coefficient based on historical scaling data.
      *
-     * <p>The scaling coefficient is computed using a weighted least squares approach, where more
-     * recent data points and those with higher parallelism are given higher weights. If there are
-     * not enough observations, or if the computed coefficient is invalid, a default value of {@code
+     * <p>The scaling coefficient is computed using the least squares approach. If there are not
+     * enough observations, or if the computed coefficient is invalid, a default value of {@code
      * 1.0} is returned, assuming linear scaling.
      *
      * @param history A {@code SortedMap} of {@code Instant} timestamps to {@code ScalingSummary}
-     * @param minObservations The minimum number of observations required to compute the scaling
-     *     coefficient. If the number of historical entries is less than this threshold, a default
-     *     coefficient of {@code 1.0} is returned.
+     * @param conf Deployment configuration.
      * @return The computed scaling coefficient.
      */
     @VisibleForTesting
     protected static double calculateObservedScalingCoefficient(
-            SortedMap<Instant, ScalingSummary> history, int minObservations) {
+            SortedMap<Instant, ScalingSummary> history, Configuration conf) {
         /*
-         * The scaling coefficient is computed using a **weighted least squares** approach
+         * The scaling coefficient is computed using the least squares approach
          * to fit a linear model:
          *
          *      R_i = β * P_i * α
@@ -277,18 +274,21 @@ public class JobVertexScaler<KEY, Context extends JobAutoScalerContext<KEY>> {
          * - β   = baseline processing rate
          * - α   = scaling coefficient to optimize
          *
-         * The optimization minimizes the **weighted sum of squared errors**:
+         * The optimization minimizes the **sum of squared errors**:
          *
-         *      Loss = ∑ w_i * (R_i - β * α * P_i)^2
+         *      Loss = ∑ (R_i - β * α * P_i)^2
          *
          * Differentiating w.r.t. α and solving for α:
          *
-         *      α = ∑ (w_i * P_i * R_i) / (∑ (w_i * P_i^2) * β)
+         *      α = ∑ (P_i * R_i) / (∑ (P_i^2) * β)
          *
-         * We keep the system conservative for higher returns scenario by clamping computed α within 1.0.
+         * We keep the system conservative for higher returns scenario by clamping computed α to an upper bound of 1.0.
+         * If the computed coefficient falls below threshold, the system falls back to assuming linear scaling (α = 1.0).
          */
 
-        // not enough data to compute scaling coefficient. we assume linear scaling.
+        var minObservations = conf.get(OBSERVED_SCALABILITY_MIN_OBSERVATIONS);
+
+        // not enough data to compute scaling coefficient; we assume linear scaling.
         if (history.isEmpty() || history.size() < minObservations) {
             return 1.0;
         }
@@ -299,14 +299,10 @@ public class JobVertexScaler<KEY, Context extends JobAutoScalerContext<KEY>> {
             return 1.0;
         }
 
-        Instant latestTimestamp = history.lastKey();
-
         List<Double> parallelismList = new ArrayList<>();
         List<Double> processingRateList = new ArrayList<>();
-        List<Double> weightList = new ArrayList<>();
 
         for (Map.Entry<Instant, ScalingSummary> entry : history.entrySet()) {
-            Instant timestamp = entry.getKey();
             ScalingSummary summary = entry.getValue();
             double parallelism = summary.getCurrentParallelism();
             double processingRate = summary.getMetrics().get(TRUE_PROCESSING_RATE).getAverage();
@@ -317,25 +313,24 @@ public class JobVertexScaler<KEY, Context extends JobAutoScalerContext<KEY>> {
                 return 1.0;
             }
 
-            // Compute weight based on recency & parallelism
-            double timeDiff =
-                    Duration.between(timestamp, latestTimestamp).getSeconds()
-                            + 1; // Avoid division by zero
-            double weight = parallelism / timeDiff;
-
             parallelismList.add(parallelism);
             processingRateList.add(processingRate);
-            weightList.add(weight);
         }
 
         var coefficient =
                 AutoScalerUtils.optimizeLinearScalingCoefficient(
-                        parallelismList,
-                        processingRateList,
-                        weightList,
-                        baselineProcessingRate,
-                        1,
-                        0.01);
+                        parallelismList, processingRateList, baselineProcessingRate, 1, 0.01);
+
+        double threshold =
+                conf.get(AutoScalerOptions.SCALING_EFFECTIVENESS_DETECTION_ENABLED)
+                        ? conf.get(AutoScalerOptions.SCALING_EFFECTIVENESS_THRESHOLD)
+                        : 0.5;
+
+        if (coefficient < threshold) {
+            LOG.warn("Scaling coefficient is below threshold. Falling back to linear scaling.");
+            return 1.0;
+        }
+
         return BigDecimal.valueOf(coefficient).setScale(2, RoundingMode.CEILING).doubleValue();
     }
 

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/config/AutoScalerOptions.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/config/AutoScalerOptions.java
@@ -389,7 +389,10 @@ public class AutoScalerOptions {
                     .defaultValue(false)
                     .withFallbackKeys(oldOperatorConfigKey("observed-scalability.enabled"))
                     .withDescription(
-                            "Enables the use of an observed scalability coefficient when computing target parallelism. If enabled, the system will estimate the scalability coefficient based on historical scaling data instead of assuming perfect linear scaling. This helps account for real-world inefficiencies such as network overhead and coordination costs.");
+                            "Enables the use of an observed scalability coefficient when computing target parallelism. "
+                                    + "If enabled, the system will estimate the scalability coefficient based on historical scaling data "
+                                    + "instead of assuming perfect linear scaling. "
+                                    + "This helps account for real-world inefficiencies such as network overhead and coordination costs.");
 
     public static final ConfigOption<Integer> OBSERVED_SCALABILITY_MIN_OBSERVATIONS =
             autoScalerConfig("observed-scalability.min-observations")
@@ -405,4 +408,14 @@ public class AutoScalerOptions {
                                     + VERTEX_SCALING_HISTORY_COUNT.key()
                                     + " to a very high value, as the number of retained data points is limited by the size of the state store—"
                                     + "particularly when using Kubernetes-based state store.");
+
+    public static final ConfigOption<Double> OBSERVED_SCALABILITY_COEFFICIENT_MIN =
+            autoScalerConfig("observed-scalability.coefficient-min")
+                    .doubleType()
+                    .defaultValue(0.5)
+                    .withFallbackKeys(oldOperatorConfigKey("observed-scalability.coefficient-min"))
+                    .withDescription(
+                            "Minimum allowed value for the observed scalability coefficient. "
+                                    + "Prevents aggressive scaling by clamping low coefficient estimates. "
+                                    + "If the estimated coefficient falls below this value, it is capped at the configured minimum.");
 }

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/config/AutoScalerOptions.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/config/AutoScalerOptions.java
@@ -394,8 +394,15 @@ public class AutoScalerOptions {
     public static final ConfigOption<Integer> OBSERVED_SCALABILITY_MIN_OBSERVATIONS =
             autoScalerConfig("observed-scalability.min-observations")
                     .intType()
-                    .defaultValue(5)
+                    .defaultValue(3)
                     .withFallbackKeys(oldOperatorConfigKey("observed-scalability.min-observations"))
                     .withDescription(
-                            "Defines the minimum number of historical scaling observations required to estimate the scalability coefficient. If the number of available observations is below this threshold, the system falls back to assuming linear scaling.");
+                            "Defines the minimum number of historical scaling observations required to estimate the scalability coefficient. "
+                                    + "If the number of available observations is below this threshold, the system falls back to assuming linear scaling. "
+                                    + "Note: To effectively use a higher minimum observation count, you need to increase "
+                                    + VERTEX_SCALING_HISTORY_COUNT.key()
+                                    + ". Avoid setting "
+                                    + VERTEX_SCALING_HISTORY_COUNT.key()
+                                    + " to a very high value, as the number of retained data points is limited by the size of the state store—"
+                                    + "particularly when using Kubernetes-based state store.");
 }

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/config/AutoScalerOptions.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/config/AutoScalerOptions.java
@@ -382,4 +382,20 @@ public class AutoScalerOptions {
                                             "scaling.key-group.partitions.adjust.mode"))
                             .withDescription(
                                     "How to adjust the parallelism of Source vertex or upstream shuffle is keyBy");
+
+    public static final ConfigOption<Boolean> OBSERVED_SCALABILITY_ENABLED =
+            autoScalerConfig("observed-scalability.enabled")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withFallbackKeys(oldOperatorConfigKey("observed-scalability.enabled"))
+                    .withDescription(
+                            "Enables the use of an observed scalability coefficient when computing target parallelism. If enabled, the system will estimate the scalability coefficient based on historical scaling data instead of assuming perfect linear scaling. This helps account for real-world inefficiencies such as network overhead and coordination costs.");
+
+    public static final ConfigOption<Integer> OBSERVED_SCALABILITY_MIN_OBSERVATIONS =
+            autoScalerConfig("observed-scalability.min-observations")
+                    .intType()
+                    .defaultValue(5)
+                    .withFallbackKeys(oldOperatorConfigKey("observed-scalability.min-observations"))
+                    .withDescription(
+                            "Defines the minimum number of historical scaling observations required to estimate the scalability coefficient. If the number of available observations is below this threshold, the system falls back to assuming linear scaling.");
 }

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/utils/AutoScalerUtils.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/utils/AutoScalerUtils.java
@@ -101,19 +101,16 @@ public class AutoScalerUtils {
     }
 
     /**
-     * Computes the optimized linear scaling coefficient (α) by minimizing the weighted least
-     * squares error.
+     * Computes the optimized linear scaling coefficient (α) by minimizing the least squares error.
      *
      * <p>This method estimates the scaling coefficient in a linear scaling model by fitting
-     * observed processing rates and parallelism levels while applying weights to account for
-     * recency and significance.
+     * observed processing rates and parallelism levels.
      *
      * <p>The computed coefficient is clamped within the specified lower and upper bounds to ensure
      * stability and prevent extreme scaling adjustments.
      *
      * @param parallelismLevels List of parallelism levels.
      * @param processingRates List of observed processing rates.
-     * @param weights List of weights for each observation.
      * @param baselineProcessingRate Baseline processing rate.
      * @param upperBound Maximum allowable value for the scaling coefficient.
      * @param lowerBound Minimum allowable value for the scaling coefficient.
@@ -123,28 +120,26 @@ public class AutoScalerUtils {
     public static double optimizeLinearScalingCoefficient(
             List<Double> parallelismLevels,
             List<Double> processingRates,
-            List<Double> weights,
             double baselineProcessingRate,
             double upperBound,
             double lowerBound) {
 
-        double weightedSum = 0.0;
-        double weightedSquaredSum = 0.0;
+        double sum = 0.0;
+        double squaredSum = 0.0;
 
         for (int i = 0; i < parallelismLevels.size(); i++) {
             double parallelism = parallelismLevels.get(i);
             double processingRate = processingRates.get(i);
-            double weight = weights.get(i);
 
-            weightedSum += weight * parallelism * processingRate;
-            weightedSquaredSum += weight * parallelism * parallelism;
+            sum += parallelism * processingRate;
+            squaredSum += parallelism * parallelism;
         }
 
-        if (weightedSquaredSum == 0.0) {
+        if (squaredSum == 0.0) {
             return 1.0; // Fallback to linear scaling if denominator is zero
         }
 
-        double alpha = weightedSum / (weightedSquaredSum * baselineProcessingRate);
+        double alpha = sum / (squaredSum * baselineProcessingRate);
 
         return Math.max(lowerBound, Math.min(upperBound, alpha));
     }

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/JobVertexScalerTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/JobVertexScalerTest.java
@@ -50,7 +50,9 @@ import static org.apache.flink.autoscaler.JobVertexScaler.INEFFECTIVE_SCALING;
 import static org.apache.flink.autoscaler.JobVertexScaler.SCALE_LIMITED_MESSAGE_FORMAT;
 import static org.apache.flink.autoscaler.JobVertexScaler.SCALING_LIMITED;
 import static org.apache.flink.autoscaler.config.AutoScalerOptions.OBSERVED_SCALABILITY_ENABLED;
+import static org.apache.flink.autoscaler.config.AutoScalerOptions.OBSERVED_SCALABILITY_MIN_OBSERVATIONS;
 import static org.apache.flink.autoscaler.config.AutoScalerOptions.UTILIZATION_TARGET;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -1163,128 +1165,146 @@ public class JobVertexScalerTest {
         var currentTime = Instant.now();
 
         var linearScalingHistory = new TreeMap<Instant, ScalingSummary>();
-        var linearScalingEvaluatedData1 = evaluated(1, 100, 50);
-        var linearScalingEvaluatedData2 = evaluated(2, 200, 100);
-        var linearScalingEvaluatedData3 = evaluated(4, 100, 200);
-        var linearScalingEvaluatedData4 = evaluated(2, 400, 100);
-        var linearScalingEvaluatedData5 = evaluated(8, 800, 400);
+        var linearScalingEvaluatedData1 = evaluated(4, 100, 200);
+        var linearScalingEvaluatedData2 = evaluated(2, 400, 100);
+        var linearScalingEvaluatedData3 = evaluated(8, 800, 400);
 
-        linearScalingHistory.put(
-                currentTime.minusSeconds(40),
-                new ScalingSummary(1, 2, linearScalingEvaluatedData1));
-        linearScalingHistory.put(
-                currentTime.minusSeconds(30),
-                new ScalingSummary(2, 4, linearScalingEvaluatedData2));
         linearScalingHistory.put(
                 currentTime.minusSeconds(20),
-                new ScalingSummary(4, 2, linearScalingEvaluatedData3));
+                new ScalingSummary(4, 2, linearScalingEvaluatedData1));
         linearScalingHistory.put(
                 currentTime.minusSeconds(10),
-                new ScalingSummary(2, 8, linearScalingEvaluatedData4));
+                new ScalingSummary(2, 8, linearScalingEvaluatedData2));
         linearScalingHistory.put(
-                currentTime, new ScalingSummary(8, 16, linearScalingEvaluatedData5));
+                currentTime, new ScalingSummary(8, 16, linearScalingEvaluatedData3));
 
         double linearScalingScalingCoefficient =
-                JobVertexScaler.calculateObservedScalingCoefficient(linearScalingHistory, 5);
+                JobVertexScaler.calculateObservedScalingCoefficient(linearScalingHistory, conf);
 
         assertEquals(1.0, linearScalingScalingCoefficient);
 
         var slightDiminishingReturnsScalingHistory = new TreeMap<Instant, ScalingSummary>();
-        var slightDiminishingReturnsEvaluatedData1 = evaluated(1, 100, 50);
-        var slightDiminishingReturnsEvaluatedData2 = evaluated(2, 196, 98);
-        var slightDiminishingReturnsEvaluatedData3 = evaluated(4, 98, 196);
-        var slightDiminishingReturnsEvaluatedData4 = evaluated(2, 396, 99);
-        var slightDiminishingReturnsEvaluatedData5 = evaluated(8, 780, 390);
+        var slightDiminishingReturnsEvaluatedData1 = evaluated(4, 98, 196);
+        var slightDiminishingReturnsEvaluatedData2 = evaluated(2, 396, 99);
+        var slightDiminishingReturnsEvaluatedData3 = evaluated(8, 780, 390);
 
         slightDiminishingReturnsScalingHistory.put(
-                currentTime.minusSeconds(40),
-                new ScalingSummary(1, 2, slightDiminishingReturnsEvaluatedData1));
-        slightDiminishingReturnsScalingHistory.put(
-                currentTime.minusSeconds(30),
-                new ScalingSummary(2, 4, slightDiminishingReturnsEvaluatedData2));
-        slightDiminishingReturnsScalingHistory.put(
                 currentTime.minusSeconds(20),
-                new ScalingSummary(4, 2, slightDiminishingReturnsEvaluatedData3));
+                new ScalingSummary(4, 2, slightDiminishingReturnsEvaluatedData1));
         slightDiminishingReturnsScalingHistory.put(
                 currentTime.minusSeconds(10),
-                new ScalingSummary(2, 8, slightDiminishingReturnsEvaluatedData4));
+                new ScalingSummary(2, 8, slightDiminishingReturnsEvaluatedData2));
         slightDiminishingReturnsScalingHistory.put(
-                currentTime, new ScalingSummary(8, 16, slightDiminishingReturnsEvaluatedData5));
+                currentTime, new ScalingSummary(8, 16, slightDiminishingReturnsEvaluatedData3));
 
         double slightDiminishingReturnsScalingCoefficient =
                 JobVertexScaler.calculateObservedScalingCoefficient(
-                        slightDiminishingReturnsScalingHistory, 5);
+                        slightDiminishingReturnsScalingHistory, conf);
 
         assertTrue(
                 slightDiminishingReturnsScalingCoefficient > 0.9
                         && slightDiminishingReturnsScalingCoefficient < 1);
 
         var sharpDiminishingReturnsScalingHistory = new TreeMap<Instant, ScalingSummary>();
-        var sharpDiminishingReturnsEvaluatedData1 = evaluated(1, 100, 50);
-        var sharpDiminishingReturnsEvaluatedData2 = evaluated(2, 192, 96);
-        var sharpDiminishingReturnsEvaluatedData3 = evaluated(4, 80, 160);
-        var sharpDiminishingReturnsEvaluatedData4 = evaluated(2, 384, 96);
-        var sharpDiminishingReturnsEvaluatedData5 = evaluated(8, 480, 240);
+        var sharpDiminishingReturnsEvaluatedData1 = evaluated(4, 80, 160);
+        var sharpDiminishingReturnsEvaluatedData2 = evaluated(2, 384, 96);
+        var sharpDiminishingReturnsEvaluatedData3 = evaluated(8, 480, 240);
 
         sharpDiminishingReturnsScalingHistory.put(
-                currentTime.minusSeconds(40),
-                new ScalingSummary(1, 2, sharpDiminishingReturnsEvaluatedData1));
-        sharpDiminishingReturnsScalingHistory.put(
-                currentTime.minusSeconds(30),
-                new ScalingSummary(2, 4, sharpDiminishingReturnsEvaluatedData2));
-        sharpDiminishingReturnsScalingHistory.put(
                 currentTime.minusSeconds(20),
-                new ScalingSummary(4, 2, sharpDiminishingReturnsEvaluatedData3));
+                new ScalingSummary(4, 2, sharpDiminishingReturnsEvaluatedData1));
         sharpDiminishingReturnsScalingHistory.put(
                 currentTime.minusSeconds(10),
-                new ScalingSummary(2, 8, sharpDiminishingReturnsEvaluatedData4));
+                new ScalingSummary(2, 8, sharpDiminishingReturnsEvaluatedData2));
         sharpDiminishingReturnsScalingHistory.put(
-                currentTime, new ScalingSummary(8, 16, sharpDiminishingReturnsEvaluatedData5));
+                currentTime, new ScalingSummary(8, 16, sharpDiminishingReturnsEvaluatedData3));
 
         double sharpDiminishingReturnsScalingCoefficient =
                 JobVertexScaler.calculateObservedScalingCoefficient(
-                        sharpDiminishingReturnsScalingHistory, 5);
+                        sharpDiminishingReturnsScalingHistory, conf);
 
         assertTrue(
                 sharpDiminishingReturnsScalingCoefficient < 0.9
                         && sharpDiminishingReturnsScalingCoefficient > 0.4);
 
-        var sharpDiminishingReturnsWithoutOneParallelismScalingHistory =
+        var sharpDiminishingReturnsWithOneParallelismScalingHistory =
                 new TreeMap<Instant, ScalingSummary>();
-        var sharpDiminishingReturnsWithoutOneParallelismEvaluatedData1 = evaluated(4, 80, 160);
-        var sharpDiminishingReturnsWithoutOneParallelismEvaluatedData2 = evaluated(8, 480, 240);
-        var sharpDiminishingReturnsWithoutOneParallelismEvaluatedData3 = evaluated(16, 140, 280);
-        var sharpDiminishingReturnsWithoutOneParallelismEvaluatedData4 = evaluated(8, 480, 240);
-        var sharpDiminishingReturnsWithoutOneParallelismEvaluatedData5 = evaluated(16, 560, 280);
+        var sharpDiminishingReturnsWithOneParallelismEvaluatedData1 = evaluated(1, 100, 50);
+        var sharpDiminishingReturnsWithOneParallelismEvaluatedData2 = evaluated(2, 160, 80);
+        var sharpDiminishingReturnsWithOneParallelismEvaluatedData3 = evaluated(4, 200, 100);
 
-        sharpDiminishingReturnsWithoutOneParallelismScalingHistory.put(
-                currentTime.minusSeconds(40),
-                new ScalingSummary(
-                        4, 8, sharpDiminishingReturnsWithoutOneParallelismEvaluatedData1));
-        sharpDiminishingReturnsWithoutOneParallelismScalingHistory.put(
-                currentTime.minusSeconds(30),
-                new ScalingSummary(
-                        8, 16, sharpDiminishingReturnsWithoutOneParallelismEvaluatedData2));
-        sharpDiminishingReturnsWithoutOneParallelismScalingHistory.put(
+        sharpDiminishingReturnsWithOneParallelismScalingHistory.put(
                 currentTime.minusSeconds(20),
-                new ScalingSummary(
-                        16, 8, sharpDiminishingReturnsWithoutOneParallelismEvaluatedData3));
-        sharpDiminishingReturnsWithoutOneParallelismScalingHistory.put(
+                new ScalingSummary(1, 2, sharpDiminishingReturnsWithOneParallelismEvaluatedData1));
+        sharpDiminishingReturnsWithOneParallelismScalingHistory.put(
                 currentTime.minusSeconds(10),
-                new ScalingSummary(
-                        8, 16, sharpDiminishingReturnsWithoutOneParallelismEvaluatedData4));
-        sharpDiminishingReturnsWithoutOneParallelismScalingHistory.put(
+                new ScalingSummary(2, 4, sharpDiminishingReturnsWithOneParallelismEvaluatedData2));
+        sharpDiminishingReturnsWithOneParallelismScalingHistory.put(
                 currentTime,
-                new ScalingSummary(
-                        16, 32, sharpDiminishingReturnsWithoutOneParallelismEvaluatedData5));
+                new ScalingSummary(4, 8, sharpDiminishingReturnsWithOneParallelismEvaluatedData3));
 
-        double sharpDiminishingReturnsWithoutOneParallelismScalingCoefficient =
+        double sharpDiminishingReturnsWithOneParallelismScalingCoefficient =
                 JobVertexScaler.calculateObservedScalingCoefficient(
-                        sharpDiminishingReturnsWithoutOneParallelismScalingHistory, 5);
+                        sharpDiminishingReturnsWithOneParallelismScalingHistory, conf);
 
         assertTrue(
-                sharpDiminishingReturnsWithoutOneParallelismScalingCoefficient < 0.9
-                        && sharpDiminishingReturnsWithoutOneParallelismScalingCoefficient > 0.4);
+                sharpDiminishingReturnsWithOneParallelismScalingCoefficient < 0.9
+                        && sharpDiminishingReturnsWithOneParallelismScalingCoefficient > 0.4);
+
+        conf.set(OBSERVED_SCALABILITY_MIN_OBSERVATIONS, 1);
+
+        var withOneScalingHistoryRecord = new TreeMap<Instant, ScalingSummary>();
+
+        var withOneScalingHistoryRecordEvaluatedData1 = evaluated(4, 200, 100);
+
+        withOneScalingHistoryRecord.put(
+                currentTime, new ScalingSummary(4, 8, withOneScalingHistoryRecordEvaluatedData1));
+
+        double withOneScalingHistoryRecordScalingCoefficient =
+                JobVertexScaler.calculateObservedScalingCoefficient(
+                        withOneScalingHistoryRecord, conf);
+
+        assertEquals(1, withOneScalingHistoryRecordScalingCoefficient);
+
+        var diminishingReturnWithTwoScalingHistoryRecord = new TreeMap<Instant, ScalingSummary>();
+
+        var diminishingReturnWithTwoScalingHistoryRecordEvaluatedData1 = evaluated(2, 160, 80);
+        var diminishingReturnWithTwoScalingHistoryRecordEvaluatedData2 = evaluated(4, 200, 100);
+
+        diminishingReturnWithTwoScalingHistoryRecord.put(
+                currentTime.minusSeconds(10),
+                new ScalingSummary(
+                        2, 4, diminishingReturnWithTwoScalingHistoryRecordEvaluatedData1));
+        diminishingReturnWithTwoScalingHistoryRecord.put(
+                currentTime,
+                new ScalingSummary(
+                        4, 8, diminishingReturnWithTwoScalingHistoryRecordEvaluatedData2));
+
+        double diminishingReturnWithTwoScalingHistoryRecordScalingCoefficient =
+                JobVertexScaler.calculateObservedScalingCoefficient(
+                        diminishingReturnWithTwoScalingHistoryRecord, conf);
+
+        assertTrue(
+                diminishingReturnWithTwoScalingHistoryRecordScalingCoefficient < 0.9
+                        && diminishingReturnWithTwoScalingHistoryRecordScalingCoefficient > 0.4);
+
+        var linearReturnWithTwoScalingHistoryRecord = new TreeMap<Instant, ScalingSummary>();
+
+        var linearReturnWithTwoScalingHistoryRecordEvaluatedData1 = evaluated(2, 160, 80);
+        var linearReturnWithTwoScalingHistoryRecordEvaluatedData2 = evaluated(4, 320, 160);
+
+        linearReturnWithTwoScalingHistoryRecord.put(
+                currentTime.minusSeconds(10),
+                new ScalingSummary(2, 4, linearReturnWithTwoScalingHistoryRecordEvaluatedData1));
+        linearReturnWithTwoScalingHistoryRecord.put(
+                currentTime,
+                new ScalingSummary(4, 8, linearReturnWithTwoScalingHistoryRecordEvaluatedData2));
+
+        double linearReturnWithTwoScalingHistoryRecordScalingCoefficient =
+                JobVertexScaler.calculateObservedScalingCoefficient(
+                        linearReturnWithTwoScalingHistoryRecord, conf);
+
+        assertEquals(1, linearReturnWithTwoScalingHistoryRecordScalingCoefficient);
     }
 
     @ParameterizedTest
@@ -1299,26 +1319,18 @@ public class JobVertexScalerTest {
         conf.set(OBSERVED_SCALABILITY_ENABLED, true);
 
         var linearScalingHistory = new TreeMap<Instant, ScalingSummary>();
-        var linearScalingEvaluatedData1 = evaluated(1, 100, 50);
-        var linearScalingEvaluatedData2 = evaluated(2, 200, 100);
-        var linearScalingEvaluatedData3 = evaluated(4, 100, 200);
-        var linearScalingEvaluatedData4 = evaluated(2, 400, 100);
-        var linearScalingEvaluatedData5 = evaluated(8, 800, 400);
+        var linearScalingEvaluatedData1 = evaluated(4, 100, 200);
+        var linearScalingEvaluatedData2 = evaluated(2, 400, 100);
+        var linearScalingEvaluatedData3 = evaluated(8, 800, 400);
 
         linearScalingHistory.put(
-                currentTime.minusSeconds(40),
-                new ScalingSummary(1, 2, linearScalingEvaluatedData1));
-        linearScalingHistory.put(
-                currentTime.minusSeconds(30),
-                new ScalingSummary(2, 4, linearScalingEvaluatedData2));
-        linearScalingHistory.put(
                 currentTime.minusSeconds(20),
-                new ScalingSummary(4, 2, linearScalingEvaluatedData3));
+                new ScalingSummary(4, 2, linearScalingEvaluatedData1));
         linearScalingHistory.put(
                 currentTime.minusSeconds(10),
-                new ScalingSummary(2, 8, linearScalingEvaluatedData4));
+                new ScalingSummary(2, 8, linearScalingEvaluatedData2));
         linearScalingHistory.put(
-                currentTime, new ScalingSummary(8, 16, linearScalingEvaluatedData5));
+                currentTime, new ScalingSummary(8, 16, linearScalingEvaluatedData3));
 
         assertEquals(
                 ParallelismChange.build(10, true),
@@ -1331,109 +1343,28 @@ public class JobVertexScalerTest {
                         restartTime,
                         delayedScaleDown));
 
-        var slightDiminishingReturnsScalingHistory = new TreeMap<Instant, ScalingSummary>();
-        var slightDiminishingReturnsEvaluatedData1 = evaluated(1, 100, 50);
-        var slightDiminishingReturnsEvaluatedData2 = evaluated(2, 196, 98);
-        var slightDiminishingReturnsEvaluatedData3 = evaluated(4, 98, 196);
-        var slightDiminishingReturnsEvaluatedData4 = evaluated(2, 396, 99);
-        var slightDiminishingReturnsEvaluatedData5 = evaluated(8, 780, 390);
+        var diminishingReturnsScalingHistory = new TreeMap<Instant, ScalingSummary>();
+        var diminishingReturnsEvaluatedData1 = evaluated(4, 80, 160);
+        var diminishingReturnsEvaluatedData2 = evaluated(2, 384, 96);
+        var diminishingReturnsEvaluatedData3 = evaluated(8, 480, 240);
 
-        slightDiminishingReturnsScalingHistory.put(
-                currentTime.minusSeconds(40),
-                new ScalingSummary(1, 2, slightDiminishingReturnsEvaluatedData1));
-        slightDiminishingReturnsScalingHistory.put(
-                currentTime.minusSeconds(30),
-                new ScalingSummary(2, 4, slightDiminishingReturnsEvaluatedData2));
-        slightDiminishingReturnsScalingHistory.put(
+        diminishingReturnsScalingHistory.put(
                 currentTime.minusSeconds(20),
-                new ScalingSummary(4, 2, slightDiminishingReturnsEvaluatedData3));
-        slightDiminishingReturnsScalingHistory.put(
+                new ScalingSummary(4, 2, diminishingReturnsEvaluatedData1));
+        diminishingReturnsScalingHistory.put(
                 currentTime.minusSeconds(10),
-                new ScalingSummary(2, 8, slightDiminishingReturnsEvaluatedData4));
-        slightDiminishingReturnsScalingHistory.put(
-                currentTime, new ScalingSummary(8, 16, slightDiminishingReturnsEvaluatedData5));
+                new ScalingSummary(2, 8, diminishingReturnsEvaluatedData2));
+        diminishingReturnsScalingHistory.put(
+                currentTime, new ScalingSummary(8, 16, diminishingReturnsEvaluatedData3));
 
         assertEquals(
-                ParallelismChange.build(12, true),
+                ParallelismChange.build(15, true),
                 vertexScaler.computeScaleTargetParallelism(
                         context,
                         op,
                         inputShipStrategies,
                         evaluated(2, 100, 40),
-                        slightDiminishingReturnsScalingHistory,
-                        restartTime,
-                        delayedScaleDown));
-
-        var sharpDiminishingReturnsScalingHistory = new TreeMap<Instant, ScalingSummary>();
-        var sharpDiminishingReturnsEvaluatedData1 = evaluated(1, 100, 50);
-        var sharpDiminishingReturnsEvaluatedData2 = evaluated(2, 192, 96);
-        var sharpDiminishingReturnsEvaluatedData3 = evaluated(4, 80, 160);
-        var sharpDiminishingReturnsEvaluatedData4 = evaluated(2, 384, 96);
-        var sharpDiminishingReturnsEvaluatedData5 = evaluated(8, 480, 240);
-
-        sharpDiminishingReturnsScalingHistory.put(
-                currentTime.minusSeconds(40),
-                new ScalingSummary(1, 2, sharpDiminishingReturnsEvaluatedData1));
-        sharpDiminishingReturnsScalingHistory.put(
-                currentTime.minusSeconds(30),
-                new ScalingSummary(2, 4, sharpDiminishingReturnsEvaluatedData2));
-        sharpDiminishingReturnsScalingHistory.put(
-                currentTime.minusSeconds(20),
-                new ScalingSummary(4, 2, sharpDiminishingReturnsEvaluatedData3));
-        sharpDiminishingReturnsScalingHistory.put(
-                currentTime.minusSeconds(10),
-                new ScalingSummary(2, 8, sharpDiminishingReturnsEvaluatedData4));
-        sharpDiminishingReturnsScalingHistory.put(
-                currentTime, new ScalingSummary(8, 16, sharpDiminishingReturnsEvaluatedData5));
-
-        assertEquals(
-                ParallelismChange.build(18, true),
-                vertexScaler.computeScaleTargetParallelism(
-                        context,
-                        op,
-                        inputShipStrategies,
-                        evaluated(2, 100, 40),
-                        sharpDiminishingReturnsScalingHistory,
-                        restartTime,
-                        delayedScaleDown));
-
-        var sharpDiminishingReturnsWithoutOneParallelismScalingHistory =
-                new TreeMap<Instant, ScalingSummary>();
-        var sharpDiminishingReturnsWithoutOneParallelismEvaluatedData1 = evaluated(4, 80, 160);
-        var sharpDiminishingReturnsWithoutOneParallelismEvaluatedData2 = evaluated(8, 480, 240);
-        var sharpDiminishingReturnsWithoutOneParallelismEvaluatedData3 = evaluated(16, 140, 280);
-        var sharpDiminishingReturnsWithoutOneParallelismEvaluatedData4 = evaluated(8, 480, 240);
-        var sharpDiminishingReturnsWithoutOneParallelismEvaluatedData5 = evaluated(16, 560, 280);
-
-        sharpDiminishingReturnsWithoutOneParallelismScalingHistory.put(
-                currentTime.minusSeconds(40),
-                new ScalingSummary(
-                        4, 8, sharpDiminishingReturnsWithoutOneParallelismEvaluatedData1));
-        sharpDiminishingReturnsWithoutOneParallelismScalingHistory.put(
-                currentTime.minusSeconds(30),
-                new ScalingSummary(
-                        8, 16, sharpDiminishingReturnsWithoutOneParallelismEvaluatedData2));
-        sharpDiminishingReturnsWithoutOneParallelismScalingHistory.put(
-                currentTime.minusSeconds(20),
-                new ScalingSummary(
-                        16, 8, sharpDiminishingReturnsWithoutOneParallelismEvaluatedData3));
-        sharpDiminishingReturnsWithoutOneParallelismScalingHistory.put(
-                currentTime.minusSeconds(10),
-                new ScalingSummary(
-                        8, 16, sharpDiminishingReturnsWithoutOneParallelismEvaluatedData4));
-        sharpDiminishingReturnsWithoutOneParallelismScalingHistory.put(
-                currentTime,
-                new ScalingSummary(
-                        16, 32, sharpDiminishingReturnsWithoutOneParallelismEvaluatedData5));
-
-        assertEquals(
-                ParallelismChange.build(24, true),
-                vertexScaler.computeScaleTargetParallelism(
-                        context,
-                        op,
-                        inputShipStrategies,
-                        evaluated(2, 100, 40),
-                        sharpDiminishingReturnsWithoutOneParallelismScalingHistory,
+                        diminishingReturnsScalingHistory,
                         restartTime,
                         delayedScaleDown));
     }

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/JobVertexScalerTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/JobVertexScalerTest.java
@@ -49,6 +49,7 @@ import static org.apache.flink.autoscaler.JobVertexScaler.INEFFECTIVE_MESSAGE_FO
 import static org.apache.flink.autoscaler.JobVertexScaler.INEFFECTIVE_SCALING;
 import static org.apache.flink.autoscaler.JobVertexScaler.SCALE_LIMITED_MESSAGE_FORMAT;
 import static org.apache.flink.autoscaler.JobVertexScaler.SCALING_LIMITED;
+import static org.apache.flink.autoscaler.config.AutoScalerOptions.OBSERVED_SCALABILITY_ENABLED;
 import static org.apache.flink.autoscaler.config.AutoScalerOptions.UTILIZATION_TARGET;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
@@ -1155,5 +1156,285 @@ public class JobVertexScalerTest {
         metrics.put(ScalingMetric.HEAP_MAX_USAGE_RATIO, EvaluatedScalingMetric.of(Double.NaN));
         ScalingMetricEvaluator.computeProcessingRateThresholds(metrics, conf, false, restartTime);
         return metrics;
+    }
+
+    @Test
+    public void testCalculateScalingCoefficient() {
+        var currentTime = Instant.now();
+
+        var linearScalingHistory = new TreeMap<Instant, ScalingSummary>();
+        var linearScalingEvaluatedData1 = evaluated(1, 100, 50);
+        var linearScalingEvaluatedData2 = evaluated(2, 200, 100);
+        var linearScalingEvaluatedData3 = evaluated(4, 100, 200);
+        var linearScalingEvaluatedData4 = evaluated(2, 400, 100);
+        var linearScalingEvaluatedData5 = evaluated(8, 800, 400);
+
+        linearScalingHistory.put(
+                currentTime.minusSeconds(40),
+                new ScalingSummary(1, 2, linearScalingEvaluatedData1));
+        linearScalingHistory.put(
+                currentTime.minusSeconds(30),
+                new ScalingSummary(2, 4, linearScalingEvaluatedData2));
+        linearScalingHistory.put(
+                currentTime.minusSeconds(20),
+                new ScalingSummary(4, 2, linearScalingEvaluatedData3));
+        linearScalingHistory.put(
+                currentTime.minusSeconds(10),
+                new ScalingSummary(2, 8, linearScalingEvaluatedData4));
+        linearScalingHistory.put(
+                currentTime, new ScalingSummary(8, 16, linearScalingEvaluatedData5));
+
+        double linearScalingScalingCoefficient =
+                JobVertexScaler.calculateObservedScalingCoefficient(linearScalingHistory, 5);
+
+        assertEquals(1.0, linearScalingScalingCoefficient);
+
+        var slightDiminishingReturnsScalingHistory = new TreeMap<Instant, ScalingSummary>();
+        var slightDiminishingReturnsEvaluatedData1 = evaluated(1, 100, 50);
+        var slightDiminishingReturnsEvaluatedData2 = evaluated(2, 196, 98);
+        var slightDiminishingReturnsEvaluatedData3 = evaluated(4, 98, 196);
+        var slightDiminishingReturnsEvaluatedData4 = evaluated(2, 396, 99);
+        var slightDiminishingReturnsEvaluatedData5 = evaluated(8, 780, 390);
+
+        slightDiminishingReturnsScalingHistory.put(
+                currentTime.minusSeconds(40),
+                new ScalingSummary(1, 2, slightDiminishingReturnsEvaluatedData1));
+        slightDiminishingReturnsScalingHistory.put(
+                currentTime.minusSeconds(30),
+                new ScalingSummary(2, 4, slightDiminishingReturnsEvaluatedData2));
+        slightDiminishingReturnsScalingHistory.put(
+                currentTime.minusSeconds(20),
+                new ScalingSummary(4, 2, slightDiminishingReturnsEvaluatedData3));
+        slightDiminishingReturnsScalingHistory.put(
+                currentTime.minusSeconds(10),
+                new ScalingSummary(2, 8, slightDiminishingReturnsEvaluatedData4));
+        slightDiminishingReturnsScalingHistory.put(
+                currentTime, new ScalingSummary(8, 16, slightDiminishingReturnsEvaluatedData5));
+
+        double slightDiminishingReturnsScalingCoefficient =
+                JobVertexScaler.calculateObservedScalingCoefficient(
+                        slightDiminishingReturnsScalingHistory, 5);
+
+        assertTrue(
+                slightDiminishingReturnsScalingCoefficient > 0.9
+                        && slightDiminishingReturnsScalingCoefficient < 1);
+
+        var sharpDiminishingReturnsScalingHistory = new TreeMap<Instant, ScalingSummary>();
+        var sharpDiminishingReturnsEvaluatedData1 = evaluated(1, 100, 50);
+        var sharpDiminishingReturnsEvaluatedData2 = evaluated(2, 192, 96);
+        var sharpDiminishingReturnsEvaluatedData3 = evaluated(4, 80, 160);
+        var sharpDiminishingReturnsEvaluatedData4 = evaluated(2, 384, 96);
+        var sharpDiminishingReturnsEvaluatedData5 = evaluated(8, 480, 240);
+
+        sharpDiminishingReturnsScalingHistory.put(
+                currentTime.minusSeconds(40),
+                new ScalingSummary(1, 2, sharpDiminishingReturnsEvaluatedData1));
+        sharpDiminishingReturnsScalingHistory.put(
+                currentTime.minusSeconds(30),
+                new ScalingSummary(2, 4, sharpDiminishingReturnsEvaluatedData2));
+        sharpDiminishingReturnsScalingHistory.put(
+                currentTime.minusSeconds(20),
+                new ScalingSummary(4, 2, sharpDiminishingReturnsEvaluatedData3));
+        sharpDiminishingReturnsScalingHistory.put(
+                currentTime.minusSeconds(10),
+                new ScalingSummary(2, 8, sharpDiminishingReturnsEvaluatedData4));
+        sharpDiminishingReturnsScalingHistory.put(
+                currentTime, new ScalingSummary(8, 16, sharpDiminishingReturnsEvaluatedData5));
+
+        double sharpDiminishingReturnsScalingCoefficient =
+                JobVertexScaler.calculateObservedScalingCoefficient(
+                        sharpDiminishingReturnsScalingHistory, 5);
+
+        assertTrue(
+                sharpDiminishingReturnsScalingCoefficient < 0.9
+                        && sharpDiminishingReturnsScalingCoefficient > 0.4);
+
+        var sharpDiminishingReturnsWithoutOneParallelismScalingHistory =
+                new TreeMap<Instant, ScalingSummary>();
+        var sharpDiminishingReturnsWithoutOneParallelismEvaluatedData1 = evaluated(4, 80, 160);
+        var sharpDiminishingReturnsWithoutOneParallelismEvaluatedData2 = evaluated(8, 480, 240);
+        var sharpDiminishingReturnsWithoutOneParallelismEvaluatedData3 = evaluated(16, 140, 280);
+        var sharpDiminishingReturnsWithoutOneParallelismEvaluatedData4 = evaluated(8, 480, 240);
+        var sharpDiminishingReturnsWithoutOneParallelismEvaluatedData5 = evaluated(16, 560, 280);
+
+        sharpDiminishingReturnsWithoutOneParallelismScalingHistory.put(
+                currentTime.minusSeconds(40),
+                new ScalingSummary(
+                        4, 8, sharpDiminishingReturnsWithoutOneParallelismEvaluatedData1));
+        sharpDiminishingReturnsWithoutOneParallelismScalingHistory.put(
+                currentTime.minusSeconds(30),
+                new ScalingSummary(
+                        8, 16, sharpDiminishingReturnsWithoutOneParallelismEvaluatedData2));
+        sharpDiminishingReturnsWithoutOneParallelismScalingHistory.put(
+                currentTime.minusSeconds(20),
+                new ScalingSummary(
+                        16, 8, sharpDiminishingReturnsWithoutOneParallelismEvaluatedData3));
+        sharpDiminishingReturnsWithoutOneParallelismScalingHistory.put(
+                currentTime.minusSeconds(10),
+                new ScalingSummary(
+                        8, 16, sharpDiminishingReturnsWithoutOneParallelismEvaluatedData4));
+        sharpDiminishingReturnsWithoutOneParallelismScalingHistory.put(
+                currentTime,
+                new ScalingSummary(
+                        16, 32, sharpDiminishingReturnsWithoutOneParallelismEvaluatedData5));
+
+        double sharpDiminishingReturnsWithoutOneParallelismScalingCoefficient =
+                JobVertexScaler.calculateObservedScalingCoefficient(
+                        sharpDiminishingReturnsWithoutOneParallelismScalingHistory, 5);
+
+        assertTrue(
+                sharpDiminishingReturnsWithoutOneParallelismScalingCoefficient < 0.9
+                        && sharpDiminishingReturnsWithoutOneParallelismScalingCoefficient > 0.4);
+    }
+
+    @ParameterizedTest
+    @MethodSource("adjustmentInputsProvider")
+    public void testParallelismScalingWithObservedScalingCoefficient(
+            Collection<ShipStrategy> inputShipStrategies) {
+        var op = new JobVertexID();
+        var delayedScaleDown = new DelayedScaleDown();
+        var currentTime = Instant.now();
+
+        conf.set(UTILIZATION_TARGET, 0.5);
+        conf.set(OBSERVED_SCALABILITY_ENABLED, true);
+
+        var linearScalingHistory = new TreeMap<Instant, ScalingSummary>();
+        var linearScalingEvaluatedData1 = evaluated(1, 100, 50);
+        var linearScalingEvaluatedData2 = evaluated(2, 200, 100);
+        var linearScalingEvaluatedData3 = evaluated(4, 100, 200);
+        var linearScalingEvaluatedData4 = evaluated(2, 400, 100);
+        var linearScalingEvaluatedData5 = evaluated(8, 800, 400);
+
+        linearScalingHistory.put(
+                currentTime.minusSeconds(40),
+                new ScalingSummary(1, 2, linearScalingEvaluatedData1));
+        linearScalingHistory.put(
+                currentTime.minusSeconds(30),
+                new ScalingSummary(2, 4, linearScalingEvaluatedData2));
+        linearScalingHistory.put(
+                currentTime.minusSeconds(20),
+                new ScalingSummary(4, 2, linearScalingEvaluatedData3));
+        linearScalingHistory.put(
+                currentTime.minusSeconds(10),
+                new ScalingSummary(2, 8, linearScalingEvaluatedData4));
+        linearScalingHistory.put(
+                currentTime, new ScalingSummary(8, 16, linearScalingEvaluatedData5));
+
+        assertEquals(
+                ParallelismChange.build(10, true),
+                vertexScaler.computeScaleTargetParallelism(
+                        context,
+                        op,
+                        inputShipStrategies,
+                        evaluated(2, 100, 40),
+                        linearScalingHistory,
+                        restartTime,
+                        delayedScaleDown));
+
+        var slightDiminishingReturnsScalingHistory = new TreeMap<Instant, ScalingSummary>();
+        var slightDiminishingReturnsEvaluatedData1 = evaluated(1, 100, 50);
+        var slightDiminishingReturnsEvaluatedData2 = evaluated(2, 196, 98);
+        var slightDiminishingReturnsEvaluatedData3 = evaluated(4, 98, 196);
+        var slightDiminishingReturnsEvaluatedData4 = evaluated(2, 396, 99);
+        var slightDiminishingReturnsEvaluatedData5 = evaluated(8, 780, 390);
+
+        slightDiminishingReturnsScalingHistory.put(
+                currentTime.minusSeconds(40),
+                new ScalingSummary(1, 2, slightDiminishingReturnsEvaluatedData1));
+        slightDiminishingReturnsScalingHistory.put(
+                currentTime.minusSeconds(30),
+                new ScalingSummary(2, 4, slightDiminishingReturnsEvaluatedData2));
+        slightDiminishingReturnsScalingHistory.put(
+                currentTime.minusSeconds(20),
+                new ScalingSummary(4, 2, slightDiminishingReturnsEvaluatedData3));
+        slightDiminishingReturnsScalingHistory.put(
+                currentTime.minusSeconds(10),
+                new ScalingSummary(2, 8, slightDiminishingReturnsEvaluatedData4));
+        slightDiminishingReturnsScalingHistory.put(
+                currentTime, new ScalingSummary(8, 16, slightDiminishingReturnsEvaluatedData5));
+
+        assertEquals(
+                ParallelismChange.build(12, true),
+                vertexScaler.computeScaleTargetParallelism(
+                        context,
+                        op,
+                        inputShipStrategies,
+                        evaluated(2, 100, 40),
+                        slightDiminishingReturnsScalingHistory,
+                        restartTime,
+                        delayedScaleDown));
+
+        var sharpDiminishingReturnsScalingHistory = new TreeMap<Instant, ScalingSummary>();
+        var sharpDiminishingReturnsEvaluatedData1 = evaluated(1, 100, 50);
+        var sharpDiminishingReturnsEvaluatedData2 = evaluated(2, 192, 96);
+        var sharpDiminishingReturnsEvaluatedData3 = evaluated(4, 80, 160);
+        var sharpDiminishingReturnsEvaluatedData4 = evaluated(2, 384, 96);
+        var sharpDiminishingReturnsEvaluatedData5 = evaluated(8, 480, 240);
+
+        sharpDiminishingReturnsScalingHistory.put(
+                currentTime.minusSeconds(40),
+                new ScalingSummary(1, 2, sharpDiminishingReturnsEvaluatedData1));
+        sharpDiminishingReturnsScalingHistory.put(
+                currentTime.minusSeconds(30),
+                new ScalingSummary(2, 4, sharpDiminishingReturnsEvaluatedData2));
+        sharpDiminishingReturnsScalingHistory.put(
+                currentTime.minusSeconds(20),
+                new ScalingSummary(4, 2, sharpDiminishingReturnsEvaluatedData3));
+        sharpDiminishingReturnsScalingHistory.put(
+                currentTime.minusSeconds(10),
+                new ScalingSummary(2, 8, sharpDiminishingReturnsEvaluatedData4));
+        sharpDiminishingReturnsScalingHistory.put(
+                currentTime, new ScalingSummary(8, 16, sharpDiminishingReturnsEvaluatedData5));
+
+        assertEquals(
+                ParallelismChange.build(18, true),
+                vertexScaler.computeScaleTargetParallelism(
+                        context,
+                        op,
+                        inputShipStrategies,
+                        evaluated(2, 100, 40),
+                        sharpDiminishingReturnsScalingHistory,
+                        restartTime,
+                        delayedScaleDown));
+
+        var sharpDiminishingReturnsWithoutOneParallelismScalingHistory =
+                new TreeMap<Instant, ScalingSummary>();
+        var sharpDiminishingReturnsWithoutOneParallelismEvaluatedData1 = evaluated(4, 80, 160);
+        var sharpDiminishingReturnsWithoutOneParallelismEvaluatedData2 = evaluated(8, 480, 240);
+        var sharpDiminishingReturnsWithoutOneParallelismEvaluatedData3 = evaluated(16, 140, 280);
+        var sharpDiminishingReturnsWithoutOneParallelismEvaluatedData4 = evaluated(8, 480, 240);
+        var sharpDiminishingReturnsWithoutOneParallelismEvaluatedData5 = evaluated(16, 560, 280);
+
+        sharpDiminishingReturnsWithoutOneParallelismScalingHistory.put(
+                currentTime.minusSeconds(40),
+                new ScalingSummary(
+                        4, 8, sharpDiminishingReturnsWithoutOneParallelismEvaluatedData1));
+        sharpDiminishingReturnsWithoutOneParallelismScalingHistory.put(
+                currentTime.minusSeconds(30),
+                new ScalingSummary(
+                        8, 16, sharpDiminishingReturnsWithoutOneParallelismEvaluatedData2));
+        sharpDiminishingReturnsWithoutOneParallelismScalingHistory.put(
+                currentTime.minusSeconds(20),
+                new ScalingSummary(
+                        16, 8, sharpDiminishingReturnsWithoutOneParallelismEvaluatedData3));
+        sharpDiminishingReturnsWithoutOneParallelismScalingHistory.put(
+                currentTime.minusSeconds(10),
+                new ScalingSummary(
+                        8, 16, sharpDiminishingReturnsWithoutOneParallelismEvaluatedData4));
+        sharpDiminishingReturnsWithoutOneParallelismScalingHistory.put(
+                currentTime,
+                new ScalingSummary(
+                        16, 32, sharpDiminishingReturnsWithoutOneParallelismEvaluatedData5));
+
+        assertEquals(
+                ParallelismChange.build(24, true),
+                vertexScaler.computeScaleTargetParallelism(
+                        context,
+                        op,
+                        inputShipStrategies,
+                        evaluated(2, 100, 40),
+                        sharpDiminishingReturnsWithoutOneParallelismScalingHistory,
+                        restartTime,
+                        delayedScaleDown));
     }
 }

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/JobVertexScalerTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/JobVertexScalerTest.java
@@ -52,7 +52,6 @@ import static org.apache.flink.autoscaler.JobVertexScaler.SCALING_LIMITED;
 import static org.apache.flink.autoscaler.config.AutoScalerOptions.OBSERVED_SCALABILITY_ENABLED;
 import static org.apache.flink.autoscaler.config.AutoScalerOptions.OBSERVED_SCALABILITY_MIN_OBSERVATIONS;
 import static org.apache.flink.autoscaler.config.AutoScalerOptions.UTILIZATION_TARGET;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -1179,7 +1178,7 @@ public class JobVertexScalerTest {
                 currentTime, new ScalingSummary(8, 16, linearScalingEvaluatedData3));
 
         double linearScalingScalingCoefficient =
-                JobVertexScaler.calculateObservedScalingCoefficient(linearScalingHistory, conf);
+                JobVertexScaler.calculateObservedScalingCoefficient(linearScalingHistory, 3);
 
         assertEquals(1.0, linearScalingScalingCoefficient);
 
@@ -1199,7 +1198,7 @@ public class JobVertexScalerTest {
 
         double slightDiminishingReturnsScalingCoefficient =
                 JobVertexScaler.calculateObservedScalingCoefficient(
-                        slightDiminishingReturnsScalingHistory, conf);
+                        slightDiminishingReturnsScalingHistory, 3);
 
         assertTrue(
                 slightDiminishingReturnsScalingCoefficient > 0.9
@@ -1221,7 +1220,7 @@ public class JobVertexScalerTest {
 
         double sharpDiminishingReturnsScalingCoefficient =
                 JobVertexScaler.calculateObservedScalingCoefficient(
-                        sharpDiminishingReturnsScalingHistory, conf);
+                        sharpDiminishingReturnsScalingHistory, 3);
 
         assertTrue(
                 sharpDiminishingReturnsScalingCoefficient < 0.9
@@ -1245,7 +1244,7 @@ public class JobVertexScalerTest {
 
         double sharpDiminishingReturnsWithOneParallelismScalingCoefficient =
                 JobVertexScaler.calculateObservedScalingCoefficient(
-                        sharpDiminishingReturnsWithOneParallelismScalingHistory, conf);
+                        sharpDiminishingReturnsWithOneParallelismScalingHistory, 3);
 
         assertTrue(
                 sharpDiminishingReturnsWithOneParallelismScalingCoefficient < 0.9
@@ -1261,8 +1260,7 @@ public class JobVertexScalerTest {
                 currentTime, new ScalingSummary(4, 8, withOneScalingHistoryRecordEvaluatedData1));
 
         double withOneScalingHistoryRecordScalingCoefficient =
-                JobVertexScaler.calculateObservedScalingCoefficient(
-                        withOneScalingHistoryRecord, conf);
+                JobVertexScaler.calculateObservedScalingCoefficient(withOneScalingHistoryRecord, 1);
 
         assertEquals(1, withOneScalingHistoryRecordScalingCoefficient);
 
@@ -1282,7 +1280,7 @@ public class JobVertexScalerTest {
 
         double diminishingReturnWithTwoScalingHistoryRecordScalingCoefficient =
                 JobVertexScaler.calculateObservedScalingCoefficient(
-                        diminishingReturnWithTwoScalingHistoryRecord, conf);
+                        diminishingReturnWithTwoScalingHistoryRecord, 1);
 
         assertTrue(
                 diminishingReturnWithTwoScalingHistoryRecordScalingCoefficient < 0.9
@@ -1302,7 +1300,7 @@ public class JobVertexScalerTest {
 
         double linearReturnWithTwoScalingHistoryRecordScalingCoefficient =
                 JobVertexScaler.calculateObservedScalingCoefficient(
-                        linearReturnWithTwoScalingHistoryRecord, conf);
+                        linearReturnWithTwoScalingHistoryRecord, 1);
 
         assertEquals(1, linearReturnWithTwoScalingHistoryRecordScalingCoefficient);
     }

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/JobVertexScalerTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/JobVertexScalerTest.java
@@ -1178,7 +1178,7 @@ public class JobVertexScalerTest {
                 currentTime, new ScalingSummary(8, 16, linearScalingEvaluatedData3));
 
         double linearScalingScalingCoefficient =
-                JobVertexScaler.calculateObservedScalingCoefficient(linearScalingHistory, 3);
+                JobVertexScaler.calculateObservedScalingCoefficient(linearScalingHistory, conf);
 
         assertEquals(1.0, linearScalingScalingCoefficient);
 
@@ -1198,7 +1198,7 @@ public class JobVertexScalerTest {
 
         double slightDiminishingReturnsScalingCoefficient =
                 JobVertexScaler.calculateObservedScalingCoefficient(
-                        slightDiminishingReturnsScalingHistory, 3);
+                        slightDiminishingReturnsScalingHistory, conf);
 
         assertTrue(
                 slightDiminishingReturnsScalingCoefficient > 0.9
@@ -1220,7 +1220,7 @@ public class JobVertexScalerTest {
 
         double sharpDiminishingReturnsScalingCoefficient =
                 JobVertexScaler.calculateObservedScalingCoefficient(
-                        sharpDiminishingReturnsScalingHistory, 3);
+                        sharpDiminishingReturnsScalingHistory, conf);
 
         assertTrue(
                 sharpDiminishingReturnsScalingCoefficient < 0.9
@@ -1244,7 +1244,7 @@ public class JobVertexScalerTest {
 
         double sharpDiminishingReturnsWithOneParallelismScalingCoefficient =
                 JobVertexScaler.calculateObservedScalingCoefficient(
-                        sharpDiminishingReturnsWithOneParallelismScalingHistory, 3);
+                        sharpDiminishingReturnsWithOneParallelismScalingHistory, conf);
 
         assertTrue(
                 sharpDiminishingReturnsWithOneParallelismScalingCoefficient < 0.9
@@ -1260,7 +1260,8 @@ public class JobVertexScalerTest {
                 currentTime, new ScalingSummary(4, 8, withOneScalingHistoryRecordEvaluatedData1));
 
         double withOneScalingHistoryRecordScalingCoefficient =
-                JobVertexScaler.calculateObservedScalingCoefficient(withOneScalingHistoryRecord, 1);
+                JobVertexScaler.calculateObservedScalingCoefficient(
+                        withOneScalingHistoryRecord, conf);
 
         assertEquals(1, withOneScalingHistoryRecordScalingCoefficient);
 
@@ -1280,7 +1281,7 @@ public class JobVertexScalerTest {
 
         double diminishingReturnWithTwoScalingHistoryRecordScalingCoefficient =
                 JobVertexScaler.calculateObservedScalingCoefficient(
-                        diminishingReturnWithTwoScalingHistoryRecord, 1);
+                        diminishingReturnWithTwoScalingHistoryRecord, conf);
 
         assertTrue(
                 diminishingReturnWithTwoScalingHistoryRecordScalingCoefficient < 0.9
@@ -1300,7 +1301,7 @@ public class JobVertexScalerTest {
 
         double linearReturnWithTwoScalingHistoryRecordScalingCoefficient =
                 JobVertexScaler.calculateObservedScalingCoefficient(
-                        linearReturnWithTwoScalingHistoryRecord, 1);
+                        linearReturnWithTwoScalingHistoryRecord, conf);
 
         assertEquals(1, linearReturnWithTwoScalingHistoryRecordScalingCoefficient);
     }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/validation/DefaultValidator.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/validation/DefaultValidator.java
@@ -65,6 +65,7 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import static org.apache.flink.autoscaler.config.AutoScalerOptions.OBSERVED_SCALABILITY_COEFFICIENT_MIN;
 import static org.apache.flink.autoscaler.config.AutoScalerOptions.UTILIZATION_MAX;
 import static org.apache.flink.autoscaler.config.AutoScalerOptions.UTILIZATION_MIN;
 import static org.apache.flink.autoscaler.config.AutoScalerOptions.UTILIZATION_TARGET;
@@ -622,6 +623,7 @@ public class DefaultValidator implements FlinkResourceValidator {
                         UTILIZATION_MIN,
                         0.0d,
                         flinkConfiguration.get(UTILIZATION_TARGET)),
+                validateNumber(flinkConfiguration, OBSERVED_SCALABILITY_COEFFICIENT_MIN, 0.01d, 1d),
                 CalendarUtils.validateExcludedPeriods(flinkConfiguration));
     }
 

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/validation/DefaultValidatorTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/validation/DefaultValidatorTest.java
@@ -843,6 +843,21 @@ public class DefaultValidatorTest {
     }
 
     @Test
+    public void testAutoScalerDeploymentWithInvalidScalingCoefficientMin() {
+        var result =
+                testAutoScalerConfiguration(
+                        flinkConf ->
+                                flinkConf.put(
+                                        AutoScalerOptions.OBSERVED_SCALABILITY_COEFFICIENT_MIN
+                                                .key(),
+                                        "1.2"));
+        assertErrorContains(
+                result,
+                getFormattedErrorMessage(
+                        AutoScalerOptions.OBSERVED_SCALABILITY_COEFFICIENT_MIN, 0.01d, 1d));
+    }
+
+    @Test
     public void testNonEnabledAutoScalerDeploymentJob() {
         var result =
                 testAutoScalerConfiguration(


### PR DESCRIPTION
### What is the purpose of the change

Currently, target parallelism computation assumes perfect linear scaling. However, real-time workloads often exhibit nonlinear scalability due to factors like network overhead and coordination costs.

This change introduces an observed scalability coefficient, estimated using linear regression on past (parallelism, processing rate) data, to improve the accuracy of scaling decisions.

### Brief change log

Implemented a dynamic scaling coefficient to compute target parallelism based on observed scalability. The system estimates the scalability coefficient using a least squares linear regression approach, leveraging historical (parallelism, processing rate) data.
The regression model minimises the sum of squared errors. The baseline processing rate is computed using the smallest observed parallelism in the history. Model details:

#### The Linear Model
We define a linear relationship between **parallelism (P)** and **processing rate (R)**:
```math
R_i = β * P_i * α
```
where:
- **R_i** = actual processing rate for the *i-th* data point
- **P_i** = parallelism for the *i-th* data point
- **β** = base factor (constant scale factor)
- **α** = scaling coefficient to optimize

#### Squared Error
The loss function to minimise is the **sum of squared errors (SSE)**:
```math
Loss = Σ (R_i - R̂_i)^2
```
Substituting \( R̂_i = (β α) P_i \):
```math
Loss = Σ (R_i - β α P_i)^2
```

#### Minimising the Error
Expanding \( (R_i - β α P_i)^2 \):
```math
(R_i - β α P_i)^2 = R_i^2 - 2β α P_i R_i + (β α P_i)^2
```
Summing over all data points:
```math
Loss = Σ (R_i^2 - 2β α P_i R_i + β^2 α^2 P_i^2)
```

#### Solving for α
To minimize for **α**, taking the derivative and solving we get:
```math
α = (Σ P_i R_i) / (Σ P_i^2 * β)
```

### Verifying this change

New unit tests added to cover this

### Does this pull request potentially affect one of the following parts:

Dependencies (does it add or upgrade a dependency): no
The public API, i.e., is any changes to the CustomResourceDescriptors: no
Core observer or reconciler logic that is regularly executed: no


You removed so much material I had to do it myself. can you confirm above I have accurately removed all traces of weighting 